### PR TITLE
Fix file paths in XML files

### DIFF
--- a/Attribution
+++ b/Attribution
@@ -1,6 +1,6 @@
 Fedora 41 Default
 =================
-Files: /usr/share/backgrounds/eln/default/*.png
+Files: /usr/share/backgrounds/fedora-eln/default/*.png
 Authors: Troy Dawson, Fedora Design Team
     
 

--- a/default/fedora-eln-static.xml
+++ b/default/fedora-eln-static.xml
@@ -9,6 +9,6 @@
   </starttime>
 <static>
 <duration>10000000000.0</duration>
-<file>/usr/share/backgrounds/eln/default/fedora-eln-01.png</file>
+<file>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01.png</file>
 </static>
 </background>

--- a/default/fedora-eln.xml
+++ b/default/fedora-eln.xml
@@ -12,27 +12,27 @@
 <!-- We start with day at 8 AM. It will remain up for 10 hours. -->
 <static>
 <duration>36000.0</duration>
-<file>/usr/share/backgrounds/eln/default/fedora-eln-01-day.png</file>
+<file>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-day.png</file>
 </static>
 
 <!-- Day ended and starts to transition to night at 6 PM. The transition lasts for 2 hours, ending at 8 PM. -->
 <transition type="overlay">
 <duration>7200.0</duration>
-<from>/usr/share/backgrounds/eln/default/fedora-eln-01-day.png</from>
-<to>/usr/share/backgrounds/eln/default/fedora-eln-01-night.png</to>
+<from>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-day.png</from>
+<to>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-night.png</to>
 </transition>
 
 <!-- It's 8 PM, we're showing the night till 6 AM. -->
 <static>
 <duration>36000.0</duration>
-<file>/usr/share/backgrounds/eln/default/fedora-eln-01-night.png</file>
+<file>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-night.png</file>
 </static>
 
 <!-- It's 6 AM, and we're starting to transition to day. Transition completes at 8 AM. -->
 <transition type="overlay">
 <duration>7200.0</duration>
-<from>/usr/share/backgrounds/eln/default/fedora-eln-01-night.png</from>
-<to>/usr/share/backgrounds/eln/default/fedora-eln-01-day.png</to>
+<from>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-night.png</from>
+<to>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-day.png</to>
 </transition>
 
 </background>

--- a/default/gnome-backgrounds-fedora-eln.xml
+++ b/default/gnome-backgrounds-fedora-eln.xml
@@ -3,8 +3,8 @@
 <wallpapers>
     <wallpaper deleted="false">
         <name>Fedora ELN Default</name>
-        <filename>/usr/share/backgrounds/eln/default/fedora-eln-01-day.png</filename>
-        <filename-dark>/usr/share/backgrounds/eln/default/fedora-eln-01-night.png</filename-dark>
+        <filename>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-day.png</filename>
+        <filename-dark>/usr/share/backgrounds/fedora-eln/default/fedora-eln-01-night.png</filename-dark>
         <options>zoom</options>
         <shade_type>solid</shade_type>
         <pcolor>#51a2da</pcolor>
@@ -12,7 +12,7 @@
     </wallpaper>
     <wallpaper deleted="false">
         <name>Fedora ELN Time of Day</name>
-        <filename>/usr/share/backgrounds/eln/default/fedora-eln.xml</filename>
+        <filename>/usr/share/backgrounds/fedora-eln/default/fedora-eln.xml</filename>
         <options>zoom</options>
     </wallpaper>
 </wallpapers>


### PR DESCRIPTION
These must match the installation paths defined in Makefile in order for GNOME to find them.

Once merged, a new release needs to be tagged here and updated in Fedora, then (hopefully!) the desktop will show by default on new GUI installations.

/cc @tdawson
