### PR TITLE
Add defaults for Budgie Desktop

### DIFF
--- a/default/30_budgie_org.gnome.desktop.background.default.gschema.override
+++ b/default/30_budgie_org.gnome.desktop.background.default.gschema.override
@@ -1,0 +1,3 @@
+[org.gnome.desktop.background:Budgie]
+picture-uri='file:///usr/share/backgrounds/fedora-eln/default/fedora-eln-01-day.png'
+picture-uri-dark='file:///usr/share/backgrounds/fedora-eln/default/fedora-eln-01-night.png'

--- a/default/30_budgie_org.gnome.desktop.screensaver.default.gschema.override
+++ b/default/30_budgie_org.gnome.desktop.screensaver.default.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.desktop.screensaver:Budgie]
+picture-uri='file:///usr/share/backgrounds/fedora-eln/default/fedora-eln.xml'

--- a/default/30_budgie_x.dm.slick_greeter.default.gschema.override
+++ b/default/30_budgie_x.dm.slick_greeter.default.gschema.override
@@ -1,0 +1,2 @@
+[x.dm.slick-greeter:Budgie]
+background='file:///usr/share/backgrounds/fedora-eln/default/fedora-eln-01-day.png'

--- a/fedora-eln-backgrounds.spec
+++ b/fedora-eln-backgrounds.spec
@@ -18,10 +18,13 @@ BuildRequires:  python3
 
 %if 0%{?eln}
 Provides:       system-backgrounds = %{version}-%{release}
+Provides:       system-backgrounds-budgie = %{version}-%{release}
 Provides:       system-backgrounds-gnome = %{version}-%{release}
 Provides:       system-backgrounds-kde = %{version}-%{release}
 Provides:       system-backgrounds-compat = %{version}-%{release}
 # for upgrade compatibility
+Provides:       desktop-backgrounds-budgie = %{version}-%{release}
+Obsoletes:      desktop-backgrounds-budgie
 Provides:       desktop-backgrounds-gnome = %{version}-%{release}
 Obsoletes:      desktop-backgrounds-gnome
 Provides:       desktop-backgrounds-kde = %{version}-%{release}
@@ -53,6 +56,9 @@ mkdir -p %{buildroot}%{_datadir}/glib-2.0/schemas
 install -m 644 \
     default/10_org.gnome.desktop.background.default.gschema.override \
     default/10_org.gnome.desktop.screensaver.default.gschema.override \
+    default/30_budgie_org.gnome.desktop.background.default.gschema.override \
+    default/30_budgie_org.gnome.desktop.screensaver.default.gschema.override \
+    default/30_budgie_x.dm.slick_greeter.default.gschema.override \
     %{buildroot}%{_datadir}/glib-2.0/schemas
 
 ln -s fedora-eln/default/fedora-eln-01-day.png %{buildroot}%{_datadir}/backgrounds/default.png


### PR DESCRIPTION
Budgie 10.10 is Wayland-based; its dependencies are too new for EPEL 10 but could be a candidate for 11.  (Right now, I've got it working in a COPR.)
